### PR TITLE
doc: complete English README and enhance 自己PR section

### DIFF
--- a/README .en.md
+++ b/README .en.md
@@ -1,7 +1,7 @@
 # Basic Information
 
 - Working as a software engineer at a Fintech company in Tokyo
-- Recently studying Software Architecture
+- Currently studying Software Architecture
 - Lived in Vancouver, Canada from 2021 to 2024
 
 ## Interview Articles
@@ -24,19 +24,19 @@
 ## Self PR
 
 - **Initiative & Action**
-  Over three years in Vancouver, Canada — attending a local college with zero connections — I launched a job search from scratch and secured local employment in North America. The English proficiency I built through working in Canada has reached a level where I can contribute immediately as part of an English-speaking team.
+  Over three years in Vancouver, Canada — attending a local college with no prior connections — I built my job search from scratch and secured local employment in North America. Through working in Canada, I developed English proficiency that enables me to contribute immediately as part of an English-speaking team.
 
 - **Full-Stack × Fintech Track Record**
-  At UPSIDER, I lead frontend development while also contributing across backend (Go, Kotlin), infrastructure, and security. I reduced CI pipeline runtime by up to 54%, accelerating the team's feedback loop. I eliminated a recurring early-morning manual recovery task that was happening 3 times a week (~2 hours per occurrence) by stabilizing the batch processing system. I also contributed to a zero-finding result in the PCI-DSS 4.0.1 audit, demonstrating a commitment to both reliability and development velocity.
+  At UPSIDER, I lead frontend development while also contributing across backend (Go, Kotlin), infrastructure, and security. I reduced CI pipeline runtime by up to 54%, accelerating the team's feedback loop. By stabilizing the batch processing system, I eliminated a recurring early-morning manual recovery task that occurred three times a week (approximately two hours each time). I also contributed to a zero-finding result in the PCI-DSS 4.0.1 audit, demonstrating a commitment to both reliability and development velocity.
 
 - **Active Participation in Study Groups & Meetups**
   I regularly attend online and in-person study groups and meetups to expand my network and deepen my knowledge.
 
 - **Communication Skills & English**
-  From my college days, I frequently took on leadership roles in multinational teams. In my current role, I serve as Security Champion, leading internal security awareness efforts. I also planned and ran a 40-person company-wide offsite end-to-end, showing that my contributions extend well beyond engineering.
+  From my college days, I frequently took on leadership roles in multinational teams. In my current role, I serve as Security Champion, leading internal security awareness efforts. I also planned and executed a company-wide 40-person offsite from start to finish, demonstrating that my contributions extend well beyond engineering.
 
 - **Extensibility-Focused Design Philosophy**
-  I always approach feature development with changeability and simplicity in mind — writing code that future team members can work with confidently, not just code that runs. I stay current through continuous learning, including participation in an O'Reilly book club reading *Software Architecture: The Hard Parts*.
+  I always approach feature development with maintainability and simplicity in mind — writing code that future team members can work with confidently, not just code that runs. I stay current through continuous learning, including participation in an O'Reilly book club reading *Software Architecture: The Hard Parts*.
 
 ## Favorite Books
 

--- a/README .en.md
+++ b/README .en.md
@@ -1,7 +1,3 @@
-Highly skilled and motivated software developer with extensive experience in frontend and backend development, specializing in building scalable web applications using TypeScript, React, Next.js, and Python. Proven track record of improving user experience, optimizing system performance, and implementing internationalization solutions for global reach. Demonstrates strong collaboration skills, working effectively with multidisciplinary teams, including designers, product managers, and QA engineers, in both English and Japanese. Adept at leading tasks that require analytical thinking, innovation, and meticulous attention to detail.
-
-Proficient in Agile development practices and passionate about delivering high-quality products that solve real-world user challenges. Equipped with business-level English communication skills, enabling seamless interaction in international environments.
-
 # Basic Information
 
 - Working as a software engineer at a Fintech company in Tokyo

--- a/README .en.md
+++ b/README .en.md
@@ -2,8 +2,52 @@ Highly skilled and motivated software developer with extensive experience in fro
 
 Proficient in Agile development practices and passionate about delivering high-quality products that solve real-world user challenges. Equipped with business-level English communication skills, enabling seamless interaction in international environments.
 
-More detail is on its way..
-Stay tuned :)
+# Basic Information
 
-Meanwhile you can see me on LinkedIn
+- Working as a software engineer at a Fintech company in Tokyo
+- Recently studying Software Architecture
+- Lived in Vancouver, Canada from 2021 to 2024
+
+## Interview Articles
+
+- [Three Years in Canada](https://frogagent.com/interview/yuto/)
+- [Joining UPSIDER](https://note.com/upsider_inc/n/n31b07b1a38b1)
+
+# Resume / Work History
+
+- [Web Page](https://ayut0.github.io/yuto-yamakita/)
+
+# About Me
+
+## Interests
+
+- Travel
+- Watching sports
+- Healthy living (gym, building habits)
+
+## Self PR
+
+- **Initiative & Action**
+  Over three years in Vancouver, Canada — attending a local college with zero connections — I launched a job search from scratch and secured local employment in North America. The English proficiency I built through working in Canada has reached a level where I can contribute immediately as part of an English-speaking team.
+
+- **Full-Stack × Fintech Track Record**
+  At UPSIDER, I lead frontend development while also contributing across backend (Go, Kotlin), infrastructure, and security. I reduced CI pipeline runtime by up to 54%, accelerating the team's feedback loop. I eliminated a recurring early-morning manual recovery task that was happening 3 times a week (~2 hours per occurrence) by stabilizing the batch processing system. I also contributed to a zero-finding result in the PCI-DSS 4.0.1 audit, demonstrating a commitment to both reliability and development velocity.
+
+- **Active Participation in Study Groups & Meetups**
+  I regularly attend online and in-person study groups and meetups to expand my network and deepen my knowledge.
+
+- **Communication Skills & English**
+  From my college days, I frequently took on leadership roles in multinational teams. In my current role, I serve as Security Champion, leading internal security awareness efforts. I also planned and ran a 40-person company-wide offsite end-to-end, showing that my contributions extend well beyond engineering.
+
+- **Extensibility-Focused Design Philosophy**
+  I always approach feature development with changeability and simplicity in mind — writing code that future team members can work with confidently, not just code that runs. I stay current through continuous learning, including participation in an O'Reilly book club reading *Software Architecture: The Hard Parts*.
+
+## Favorite Books
+
+- [Atomic Habits](https://amzn.asia/d/2z5YVwu)
+- [The Pragmatic Programmer](https://amzn.asia/d/33HsBK0)
+- [Kobe: Life Lessons from a Legend](https://amzn.asia/d/33HsBK0)
+
+## Links
+
 - [LinkedIn](https://www.linkedin.com/in/yuto-yamakita/)


### PR DESCRIPTION
## Why
The English README (`README .en.md`) was a placeholder stub. This PR completes it with the full profile content so international readers get the same information as the Japanese version.

## What changed
- `README .en.md`: replaced the placeholder "More detail is on its way" with a complete English profile — basic info, interview article links, work history link, interests, self PR (5 points), and favorite books
- `README.md`: enhanced the 自己PR section with more specific and quantified achievements (CI pipeline reduction, PCI-DSS audit result, batch stabilization, etc.)

## Risks
None — documentation-only changes with no code impact.

## Test plan
- [ ] Verify `README .en.md` renders correctly on GitHub
- [ ] Check all links in the English README are valid
- [ ] Confirm the Japanese `README.md` self PR section reads naturally with the updated content

Closes #12